### PR TITLE
fix: move cheerio and zod to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,14 @@ A TypeScript/JavaScript library for scraping recipe data from various cooking we
 
 ## Installation
 
-Add the `recipe-scrapers-js` package and its peer dependencies.
-
 ```bash
-npm install recipe-scrapers-js cheerio zod
+npm install recipe-scrapers-js
 # or
-yarn add recipe-scrapers-js cheerio zod
+yarn add recipe-scrapers-js
 # or
-pnpm add recipe-scrapers-js cheerio zod
+pnpm add recipe-scrapers-js
 # or
-bun add recipe-scrapers-js cheerio zod
+bun add recipe-scrapers-js
 ```
 
 ## Usage

--- a/bun.lock
+++ b/bun.lock
@@ -1,24 +1,21 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "recipe-scrapers-js",
       "dependencies": {
+        "cheerio": "^1.1.2",
         "iso8601-duration": "^2.1.3",
         "parse-ingredient": "^1.3.3",
-        "schema-dts": "^1.1.5",
+        "zod": "^4.3.5",
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.11",
         "@types/bun": "^1.3.0",
-        "cheerio": "^1.1.2",
+        "schema-dts": "^1.1.5",
         "tsdown": "^0.19.0",
         "typescript": "^5.9.3",
-        "zod": "^4.3.5",
-      },
-      "peerDependencies": {
-        "cheerio": "^1",
-        "zod": "^4",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -47,21 +47,17 @@
     "ts:check": "tsc --noEmit",
     "prepublishOnly": "bun run lint && bun run build"
   },
-  "peerDependencies": {
-    "cheerio": "^1",
-    "zod": "^4"
-  },
   "dependencies": {
+    "cheerio": "^1.1.2",
     "iso8601-duration": "^2.1.3",
     "parse-ingredient": "^1.3.3",
-    "schema-dts": "^1.1.5"
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
     "@types/bun": "^1.3.0",
-    "cheerio": "^1.1.2",
+    "schema-dts": "^1.1.5",
     "tsdown": "^0.19.0",
-    "typescript": "^5.9.3",
-    "zod": "^4.3.5"
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary

- Move `cheerio` and `zod` from `peerDependencies` to `dependencies` — they are runtime implementation details that consumers should not need to install separately
- Move `schema-dts` from `dependencies` to `devDependencies` — it is type-only and does not appear in the build output
- Simplify README installation instructions (no more peer deps to install manually)

## Details

The build output (`dist/index.mjs`) imports `cheerio` and `zod` at runtime, but neither is part of the public API surface — consumers never need to `import` them directly. Making them regular dependencies means `npm install recipe-scrapers-js` just works.

`schema-dts` provides TypeScript types for Schema.org and is only used via `import type`. It is correctly excluded from the bundle by tsdown/rolldown.

## Test plan

- [x] `bun run build` — identical output (56.27 kB), cheerio/zod externalized, schema-dts absent
- [x] `bun test` — 316 tests pass
- [x] `bun run lint` — clean