### PR TITLE
fix: use Cheerio for HTML entity decoding in HtmlStripperPlugin

### DIFF
--- a/src/plugins/__tests__/html-stripper.processor.test.ts
+++ b/src/plugins/__tests__/html-stripper.processor.test.ts
@@ -80,6 +80,14 @@ describe('HtmlStripperPlugin', () => {
     expect(output[1].items.map((i) => i.value)).toEqual(['3 apples'])
   })
 
+  it('decodes all HTML entities', () => {
+    expect(plugin.process('title', 'Cr&egrave;me br&ucirc;l&eacute;e')).toBe(
+      'Crème brûlée',
+    )
+    expect(plugin.process('title', '&#x27;quoted&#x27;')).toBe("'quoted'")
+    expect(plugin.process('title', '100&deg;C')).toBe('100°C')
+  })
+
   it('returns value unchanged for non-target fields', () => {
     expect(plugin.process('category', new Set(['<b>cat</b>']))).toEqual(
       new Set(['<b>cat</b>']),

--- a/src/plugins/html-stripper.processor.ts
+++ b/src/plugins/html-stripper.processor.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio'
 import { PostProcessorPlugin } from '@/abstract-postprocessor-plugin'
 import type { RecipeFields } from '@/types/recipe.interface'
 import { isString } from '@/utils'
@@ -59,16 +60,13 @@ export class HtmlStripperPlugin extends PostProcessorPlugin {
   }
 
   private stripHtml(html: string): string {
-    // Simple regex approach (could use a proper HTML parser)
-    return html
-      .replace(/<[^>]*>/g, '') // Remove HTML tags
-      .replace(/&amp;/g, '&') // Decode common entities
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#34;/g, '"')
-      .replace(/&#39;/g, "'")
-      .trim()
+    const $ = cheerio.load(html, null, false)
+    return (
+      $.root()
+        .text()
+        // Cheerio decodes &nbsp; as non-breaking space (U+00A0), normalize to regular space
+        .replace(/\u00a0/g, ' ')
+        .trim()
+    )
   }
 }


### PR DESCRIPTION
## Summary
- Replace manual regex-based entity decoding in `HtmlStripperPlugin.stripHtml()` with Cheerio's `.text()` method
- The previous implementation only decoded 6 HTML entities (`&amp;`, `&nbsp;`, `&lt;`, `&gt;`, `&quot;`, `&#34;`, `&#39;`), leaving all others (e.g. `&eacute;`, `&#x27;`, `&deg;`) unhandled
- Cheerio handles all HTML entities correctly out of the box
- Non-breaking spaces (`&nbsp;` → U+00A0) are normalized to regular spaces

## Test plan
- [x] Added test for previously unhandled entities (`&egrave;`, `&ucirc;`, `&eacute;`, `&#x27;`, `&deg;`)
- [x] All 317 existing tests pass (no regressions)
- [x] Lint clean
- [x] Build passes