### PR TITLE
feat: add sourcemaps to build output

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   entry: ['./src/index.ts'],
   dts: true,
   format: ['esm'],
+  sourcemap: true,
 })


### PR DESCRIPTION
## Summary
- Enable sourcemap generation in tsdown config (`sourcemap: true`)
- Produces `dist/index.mjs.map` (118 kB) alongside the existing bundle
- The `.mjs` bundle itself is unchanged (+160 bytes for the `sourceMappingURL` comment)
- Improves debugging experience for consumers: stack traces and breakpoints map back to original TypeScript source

## Build comparison
| File | Before | After |
|------|--------|-------|
| `dist/index.mjs` | 56.15 kB | 56.31 kB |
| `dist/index.mjs.map` | — | 117.73 kB |
| `dist/index.d.mts` | 32.30 kB | 32.33 kB |

## Test plan
- [x] Build passes
- [x] All 316 tests pass
- [x] Lint clean
- [x] Sourcemap is included in `dist/` (already covered by `"files": ["dist"]` in package.json)